### PR TITLE
there is not an `is_none` function to expose

### DIFF
--- a/gleam_stdlib/src/Result.gleam
+++ b/gleam_stdlib/src/Result.gleam
@@ -1,5 +1,5 @@
 module Result
-  exposing Result(..), is_ok/1, is_none/1, map/2, map_error/2, flatten/1,
+  exposing Result(..), is_ok/1, map/2, map_error/2, flatten/1,
     flat_map/2, unwrap/2, to_maybe/1, from_maybe/1
 
 import Maybe exposing Maybe(..)


### PR DESCRIPTION
I was surprised this did not cause an error. should exporting a function that does not exist error