### PR TITLE
Remove dot function call syntax

### DIFF
--- a/compiler/src/gleam_codegen.erl
+++ b/compiler/src/gleam_codegen.erl
@@ -123,13 +123,17 @@ map_expressions(Expressions, Env) ->
   gleam:thread_map(fun expression/2, Expressions, Env).
 
 
-fn_call(#ast_var{name = Name}, Args, Env) ->
-  C_fname = cerl:c_fname(list_to_atom(Name), length(Args)),
-  {C_args, NewEnv} = map_expressions(Args, Env),
-  {cerl:c_apply(C_fname, C_args), NewEnv};
-
 fn_call(Fn, Args, Env0) ->
-  expression(#ast_fn_call{fn = Fn, args = Args}, Env0).
+  ?print(Fn),
+  case Fn of
+    #ast_var{name = Name, scope = local} ->
+      C_fname = cerl:c_fname(list_to_atom(Name), length(Args)),
+      {C_args, NewEnv} = map_expressions(Args, Env0),
+      {cerl:c_apply(C_fname, C_args), NewEnv};
+
+    Other ->
+      expression(#ast_fn_call{fn = Fn, args = Args}, Env0)
+  end.
 
 
 expression(#ast_string{value = Value}, Env) when is_binary(Value) ->

--- a/compiler/src/gleam_codegen.erl
+++ b/compiler/src/gleam_codegen.erl
@@ -124,7 +124,6 @@ map_expressions(Expressions, Env) ->
 
 
 fn_call(Fn, Args, Env0) ->
-  ?print(Fn),
   case Fn of
     #ast_var{name = Name, scope = local} ->
       C_fname = cerl:c_fname(list_to_atom(Name), length(Args)),
@@ -197,6 +196,7 @@ expression(#ast_local_call{meta = Meta, fn = Fn, args = Args}, Env) ->
 expression(#ast_call{module = Mod, name = Name, args = Args}, Env) when is_list(Name) ->
   C_module = cerl:c_atom(prefix_module(Mod)),
   C_name = cerl:c_atom(Name),
+  ?print(Args),
   {C_args, NewEnv} = map_expressions(Args, Env),
   {cerl:c_call(C_module, C_name, C_args), NewEnv};
 

--- a/compiler/src/gleam_codegen.erl
+++ b/compiler/src/gleam_codegen.erl
@@ -125,7 +125,7 @@ map_expressions(Expressions, Env) ->
 
 fn_call(Fn, Args, Env0) ->
   case Fn of
-    #ast_var{name = Name, scope = local} ->
+    #ast_var{name = Name, scope = module} ->
       C_fname = cerl:c_fname(list_to_atom(Name), length(Args)),
       {C_args, NewEnv} = map_expressions(Args, Env0),
       {cerl:c_apply(C_fname, C_args), NewEnv};
@@ -196,7 +196,6 @@ expression(#ast_local_call{meta = Meta, fn = Fn, args = Args}, Env) ->
 expression(#ast_call{module = Mod, name = Name, args = Args}, Env) when is_list(Name) ->
   C_module = cerl:c_atom(prefix_module(Mod)),
   C_name = cerl:c_atom(Name),
-  ?print(Args),
   {C_args, NewEnv} = map_expressions(Args, Env),
   {cerl:c_call(C_module, C_name, C_args), NewEnv};
 

--- a/compiler/src/gleam_compiler.erl
+++ b/compiler/src/gleam_compiler.erl
@@ -12,8 +12,8 @@ source_to_binary(Source, ModName, Options) ->
   {ok, Forms} =
     case gleam_type:infer(Ast) of
       {ok, AnnotatedAst} ->
-        ?print(Ast),
-        ?print(AnnotatedAst),
+        % ?print(Ast),
+        % ?print(AnnotatedAst),
         gleam_codegen:module(AnnotatedAst, ModName, Options);
 
       % TODO: Remove this clause. We want to error out.

--- a/compiler/src/gleam_compiler.erl
+++ b/compiler/src/gleam_compiler.erl
@@ -9,8 +9,19 @@ source_to_binary(Source, ModName) ->
 source_to_binary(Source, ModName, Options) ->
   {ok, Tokens, _} = gleam_tokenizer:string(Source),
   {ok, Ast} = gleam_parser:parse(Tokens),
-  % _ = gleam_type:infer(Ast), % TODO
-  {ok, Forms} = gleam_codegen:module(Ast, ModName, Options),
+  {ok, Forms} =
+    case gleam_type:infer(Ast) of
+      {ok, AnnotatedAst} ->
+        ?print(Ast),
+        ?print(AnnotatedAst),
+        gleam_codegen:module(AnnotatedAst, ModName, Options);
+
+      % TODO: Remove this clause. We want to error out.
+      % Temp measure while I get full inference working.
+      {error, TypeInferError} ->
+        ?print(TypeInferError),
+        gleam_codegen:module(Ast, ModName, Options)
+    end,
   {ok, _, Bin} = compile:forms(Forms, [report, verbose, from_core]),
   Bin.
 

--- a/compiler/src/gleam_compiler.erl
+++ b/compiler/src/gleam_compiler.erl
@@ -12,8 +12,6 @@ source_to_binary(Source, ModName, Options) ->
   {ok, Forms} =
     case gleam_type:infer(Ast) of
       {ok, AnnotatedAst} ->
-        % ?print(Ast),
-        % ?print(AnnotatedAst),
         gleam_codegen:module(AnnotatedAst, ModName, Options);
 
       % TODO: Remove this clause. We want to error out.

--- a/compiler/src/gleam_records.hrl
+++ b/compiler/src/gleam_records.hrl
@@ -2,7 +2,7 @@
 
 -record(meta, {line = 1 :: non_neg_integer()}).
 -type meta() :: #meta{}.
-
+-type scope() :: local | module.
 -type export() :: {string(), non_neg_integer()}.
 -type type_annotation() :: type_not_annotated | {ok, type()}.
 
@@ -73,6 +73,7 @@
 -record(ast_var,
         {meta = #meta{},
          type = type_not_annotated :: type_annotation(),
+         scope = local :: scope(),
          name :: string()}).
 
 % TODO: Remove the type annotation so it's calculated by traversing the body

--- a/compiler/src/gleam_type.erl
+++ b/compiler/src/gleam_type.erl
@@ -161,7 +161,7 @@ infer_pattern(Pattern, Env0) ->
       {AnnotatedPattern, Env3};
 
     #ast_enum{name = Name, elems = Args} ->
-      Fn = #ast_var{name = Name},
+      Fn = #ast_var{name = Name, scope = module},
       {ReturnType, Env1} = infer_enum_pattern(Fn, Args, Env0),
       AnnotatedPattern = Pattern#ast_enum{type = {ok, ReturnType}},
       {AnnotatedPattern, Env1};
@@ -174,7 +174,7 @@ infer_pattern(Pattern, Env0) ->
     #ast_var{name = Name} ->
       {Var, Env1} = new_var(Env0),
       Env2 = env_extend(Name, Var, local, Env1),
-      AnnotatedPattern = Pattern#ast_var{type = {ok, Var}},
+      AnnotatedPattern = Pattern#ast_var{type = {ok, Var}, scope = local},
       {AnnotatedPattern, Env2};
 
     #ast_hole{} ->
@@ -224,27 +224,31 @@ infer(Ast, Env0) ->
       {AnnotatedAst, Env2};
 
     #ast_operator{name = Name, args = Args} ->
-      {ReturnType, Env1} = infer_call(#ast_var{name = Name}, Args, Env0),
-      AnnotatedAst = Ast#ast_operator{type = {ok, ReturnType}},
+      {ReturnType, _, AnnotatedArgs, Env1} = infer_call(#ast_var{name = Name}, Args, Env0),
+      AnnotatedAst = Ast#ast_operator{type = {ok, ReturnType}, args = AnnotatedArgs},
       {AnnotatedAst, Env1};
 
     #ast_fn_call{fn = Fn, args = Args} ->
-      {ReturnType, Env1} = infer_call(Fn, Args, Env0),
-      AnnotatedAst = Ast#ast_fn_call{type = {ok, ReturnType}},
+      {ReturnType, AnnotatedFn, AnnotatedArgs, Env1} = infer_call(Fn, Args, Env0),
+      AnnotatedAst = Ast#ast_fn_call{type = {ok, ReturnType},
+                                     fn = AnnotatedFn,
+                                     args = AnnotatedArgs},
       {AnnotatedAst, Env1};
 
     #ast_local_call{meta = Meta, fn = Fn, args = Args} ->
       NumHoles = length(lists:filter(fun(#ast_hole{}) -> true; (_) -> false end, Args)),
       case NumHoles of
         0 ->
-          {ReturnType, Env1} = infer_call(Fn, Args, Env0),
-          AnnotatedAst = Ast#ast_local_call{type = {ok, ReturnType}},
+          {ReturnType, AnnotatedFn, AnnotatedArgs, Env1} = infer_call(Fn, Args, Env0),
+          AnnotatedAst = Ast#ast_local_call{type = {ok, ReturnType},
+                                            fn = AnnotatedFn,
+                                            args = AnnotatedArgs},
           {AnnotatedAst, Env1};
 
         1 ->
           {UID, Env1} = uid(Env0),
           VarName = "$$gleam_hole_var" ++ integer_to_list(UID),
-          Var = #ast_var{name = VarName},
+          Var = #ast_var{name = VarName, scope = local},
           NewArgs = lists:map(fun(#ast_hole{}) -> Var; (X) -> X end, Args),
           Call = #ast_local_call{meta = Meta, fn = Fn, args = NewArgs},
           NewFn = #ast_fn{meta = Meta, args = [VarName], body = Call},
@@ -255,9 +259,9 @@ infer(Ast, Env0) ->
       end;
 
     #ast_enum{name = Name, elems = Args} ->
-      Fn = #ast_var{name = Name},
-      {ReturnType, Env1} = infer_call(Fn, Args, Env0),
-      AnnotatedAst = Ast#ast_enum{type = {ok, ReturnType}},
+      Fn = #ast_var{name = Name, scope = module},
+      {ReturnType, _, AnnotatedArgs, Env1} = infer_call(Fn, Args, Env0),
+      AnnotatedAst = Ast#ast_enum{type = {ok, ReturnType}, elems = AnnotatedArgs},
       {AnnotatedAst, Env1};
 
     #ast_fn{args = Args, body = Body} ->
@@ -268,19 +272,17 @@ infer(Ast, Env0) ->
         end,
       FnEnv = lists:foldl(Insert, ArgsEnv, lists:zip(Args, ArgTypes)),
       {AnnotatedBody, ReturnEnv} = infer(Body, FnEnv),
-      % ?print(InferredBody),
       ReturnType = fetch(AnnotatedBody),
       Type = #type_fn{args = ArgTypes, return = ReturnType},
-      ?print(AnnotatedBody),
       AnnotatedAst = Ast#ast_fn{type = {ok, Type}, body = AnnotatedBody},
       FinalEnv = Env0#env{type_refs = ReturnEnv#env.type_refs},
       {AnnotatedAst, FinalEnv};
 
     #ast_var{name = Name} ->
       case env_lookup(Name, Env0) of
-        {ok, #var_data{type = Type}} ->
+        {ok, #var_data{type = Type, scope = Scope}} ->
           {InstantiatedType, NewEnv} = instantiate(Type, Env0),
-          AnnotatedAst = Ast#ast_var{type = {ok, InstantiatedType}},
+          AnnotatedAst = Ast#ast_var{type = {ok, InstantiatedType}, scope = Scope},
           {AnnotatedAst, NewEnv};
 
         error ->
@@ -288,7 +290,7 @@ infer(Ast, Env0) ->
       end;
 
     #ast_assignment{name = Name, value = Value, then = Then} ->
-      {_ValueType, AnnotatedValue, Env1} = infer_assignment(Name, Value, Env0),
+      {_ValueType, AnnotatedValue, Env1} = infer_assignment(Name, Value, local, Env0),
       {AnnotatedThen, Env2} = infer(Then, Env1),
       AnnotatedAst = Ast#ast_assignment{value = AnnotatedValue, then = AnnotatedThen},
       {AnnotatedAst, Env2};
@@ -396,12 +398,13 @@ ast_type_to_type(AstType, Env0) ->
   end.
 
 
--spec infer_assignment(string(), ast_expression(), env()) -> {type(), ast_expression(), env()}.
-infer_assignment(Name, Value, Env0) ->
+-spec infer_assignment(string(), ast_expression(), scope(), env())
+      -> {type(), ast_expression(), env()}.
+infer_assignment(Name, Value, Scope, Env0) ->
   {InferredValue, Env2} = infer(Value, increment_env_level(Env0)),
   Env3 = decrement_env_level(Env2),
   {GeneralizedType, Env4} = generalize(fetch(InferredValue), Env3),
-  Env5 = env_extend(Name, GeneralizedType, local, Env4),
+  Env5 = env_extend(Name, GeneralizedType, Scope, Env4),
   {GeneralizedType, InferredValue, Env5}.
 
 
@@ -446,7 +449,7 @@ module_statement(Statement, {Row, Env0}) ->
 
     #ast_mod_fn{public = Public, name = Name, args = Args, body = Body} ->
       Fn = #ast_fn{args = Args, body = Body},
-      {FnType, AnnotatedFn, Env1} = infer_assignment(Name, Fn, Env0),
+      {FnType, AnnotatedFn, Env1} = infer_assignment(Name, Fn, module, Env0),
       #ast_fn{args = NewArgs, body = NewBody} = AnnotatedFn,
       NewRow = case Public of
         true -> #type_row_extend{label = Name, type = FnType, parent = Row};
@@ -469,6 +472,8 @@ module_statement(Statement, {Row, Env0}) ->
 
 % TODO: We need to return the args types from this so we can the args after
 % calling this.
+-spec infer_call(ast_expression(), [ast_expression()], env())
+      -> {type(), ast_expression(), [ast_expression()], env()}.
 infer_call(FunAst, Args, Env0) ->
   {AnnotatedFunAst, Env1} = infer(FunAst, Env0),
   FunType = fetch(AnnotatedFunAst),
@@ -478,10 +483,11 @@ infer_call(FunAst, Args, Env0) ->
     fun({ArgType, ArgExpr}, CheckEnv0) ->
       {AnnotatedArgExpr, CheckEnv1} = infer(ArgExpr, CheckEnv0),
       ArgExprType = fetch(AnnotatedArgExpr),
-      unify(ArgType, ArgExprType, CheckEnv1)
+      CheckEnv2 = unify(ArgType, ArgExprType, CheckEnv1),
+      {AnnotatedArgExpr, CheckEnv2}
     end,
-  Env3 = lists:foldl(CheckArg, Env2, lists:zip(ArgTypes, Args)),
-  {ReturnType, Env3}.
+  {AnnotatedArgs, Env3} = gleam:thread_map(CheckArg, lists:zip(ArgTypes, Args), Env2),
+  {ReturnType, AnnotatedFunAst, AnnotatedArgs, Env3}.
 
 
 -spec fetch_clause_type(#ast_clause{}) -> type().

--- a/compiler/src/gleam_type.erl
+++ b/compiler/src/gleam_type.erl
@@ -267,10 +267,12 @@ infer(Ast, Env0) ->
           env_extend(Name, Type, local, E)
         end,
       FnEnv = lists:foldl(Insert, ArgsEnv, lists:zip(Args, ArgTypes)),
-      {ReturnAst, ReturnEnv} = infer(Body, FnEnv),
-      ReturnType = fetch(ReturnAst),
+      {AnnotatedBody, ReturnEnv} = infer(Body, FnEnv),
+      % ?print(InferredBody),
+      ReturnType = fetch(AnnotatedBody),
       Type = #type_fn{args = ArgTypes, return = ReturnType},
-      AnnotatedAst = Ast#ast_fn{type = {ok, Type}},
+      ?print(AnnotatedBody),
+      AnnotatedAst = Ast#ast_fn{type = {ok, Type}, body = AnnotatedBody},
       FinalEnv = Env0#env{type_refs = ReturnEnv#env.type_refs},
       {AnnotatedAst, FinalEnv};
 
@@ -345,12 +347,12 @@ infer(Ast, Env0) ->
 
     #ast_raise{} ->
       {Var, Env1} = new_var(Env0),
-      AnnotatedAst = #ast_raise{type = {ok, Var}},
+      AnnotatedAst = Ast#ast_raise{type = {ok, Var}},
       {AnnotatedAst, Env1};
 
     #ast_throw{} ->
       {Var, Env1} = new_var(Env0),
-      AnnotatedAst = #ast_throw{type = {ok, Var}},
+      AnnotatedAst = Ast#ast_throw{type = {ok, Var}},
       {AnnotatedAst, Env1};
 
     #ast_record_empty{} ->

--- a/compiler/src/gleam_type.erl
+++ b/compiler/src/gleam_type.erl
@@ -8,6 +8,10 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
+-record(var_data,
+        {type :: type(),
+         scope :: scope()}).
+
 -type var_name() :: string().
 -type type_name() :: string().
 
@@ -31,6 +35,7 @@
   | {multiple_hole_fn, ast_expression()}
   | recursive_types.
 
+
 -spec new_var(env()) -> {type(), env()}.
 new_var(Env) ->
   Ref = erlang:make_ref(),
@@ -39,6 +44,7 @@ new_var(Env) ->
   NewEnv = env_put_type_ref(Ref, TypeVar, Env),
   {Type, NewEnv}.
 
+
 -spec new_generic_var(env()) -> {type(), env()}.
 new_generic_var(Env) ->
   Ref = erlang:make_ref(),
@@ -46,6 +52,7 @@ new_generic_var(Env) ->
   TypeVar = #type_var_generic{id = make_ref()},
   NewEnv = env_put_type_ref(Ref, TypeVar, Env),
   {Type, NewEnv}.
+
 
 -spec infer(ast_expression()) -> {ok, ast_expression()} | {error, error()}.
 infer(Ast) ->
@@ -56,6 +63,7 @@ infer(Ast) ->
   catch
     throw:{gleam_type_error, Error} -> {error, Error}
   end.
+
 
 -spec unify_clauses([#ast_clause{}], type(), env()) -> env().
 unify_clauses(Clauses, SubjectType, Env0) ->
@@ -70,6 +78,7 @@ unify_clauses(Clauses, SubjectType, Env0) ->
     end,
   {_, Env2} = lists:foldl(Unify, {First, Env1}, Rest),
   Env2.
+
 
 -spec pattern_fetch(ast_pattern()) -> type().
 pattern_fetch(Pattern) ->
@@ -164,7 +173,7 @@ infer_pattern(Pattern, Env0) ->
 
     #ast_var{name = Name} ->
       {Var, Env1} = new_var(Env0),
-      Env2 = env_extend(Name, Var, Env1),
+      Env2 = env_extend(Name, Var, local, Env1),
       AnnotatedPattern = Pattern#ast_var{type = {ok, Var}},
       {AnnotatedPattern, Env2};
 
@@ -255,7 +264,7 @@ infer(Ast, Env0) ->
       {ArgTypes, ArgsEnv} = gleam:thread_map(fun(_, E) -> new_var(E) end, Args, Env0),
       Insert =
         fun({Name, Type}, E) ->
-          env_extend(Name, Type, E)
+          env_extend(Name, Type, local, E)
         end,
       FnEnv = lists:foldl(Insert, ArgsEnv, lists:zip(Args, ArgTypes)),
       {ReturnAst, ReturnEnv} = infer(Body, FnEnv),
@@ -267,7 +276,7 @@ infer(Ast, Env0) ->
 
     #ast_var{name = Name} ->
       case env_lookup(Name, Env0) of
-        {ok, Type} ->
+        {ok, #var_data{type = Type}} ->
           {InstantiatedType, NewEnv} = instantiate(Type, Env0),
           AnnotatedAst = Ast#ast_var{type = {ok, InstantiatedType}},
           {AnnotatedAst, NewEnv};
@@ -390,7 +399,7 @@ infer_assignment(Name, Value, Env0) ->
   {InferredValue, Env2} = infer(Value, increment_env_level(Env0)),
   Env3 = decrement_env_level(Env2),
   {GeneralizedType, Env4} = generalize(fetch(InferredValue), Env3),
-  Env5 = env_extend(Name, GeneralizedType, Env4),
+  Env5 = env_extend(Name, GeneralizedType, local, Env4),
   {GeneralizedType, InferredValue, Env5}.
 
 
@@ -423,7 +432,7 @@ module_statement(Statement, {Row, Env0}) ->
         fun(#ast_enum_def{name = CName, args = CArgs}, InnerEnv0) ->
           {CArgsTypes, InnerEnv1} = gleam:thread_map(fun ast_type_to_type/2, CArgs, InnerEnv0),
           T = #type_fn{args = CArgsTypes, return = Type},
-          env_extend(CName, T, InnerEnv1)
+          env_extend(CName, T, module, InnerEnv1)
         end,
       Env2 = lists:foldl(RegisterConstructor, Env1, Constructors),
 
@@ -442,20 +451,22 @@ module_statement(Statement, {Row, Env0}) ->
         false -> Row
       end,
       NewState = {NewRow, Env1},
-      AnnotatedStatement = #ast_mod_fn{type = {ok, FnType},
-                                       args = NewArgs,
-                                       body = NewBody},
+      AnnotatedStatement = Statement#ast_mod_fn{type = {ok, FnType},
+                                                args = NewArgs,
+                                                body = NewBody},
       {AnnotatedStatement, NewState};
 
     #ast_mod_test{body = Body} ->
       Fn = #ast_fn{args = [], body = Body},
       {AnnotatedFn, Env1} = infer(Fn, Env0),
-      AnnotatedAst = #ast_mod_test{body = AnnotatedFn#ast_fn.body},
+      AnnotatedAst = Statement#ast_mod_test{body = AnnotatedFn#ast_fn.body},
       NewState = {Row, Env1},
       {AnnotatedAst, NewState}
   end.
 
 
+% TODO: We need to return the args types from this so we can the args after
+% calling this.
 infer_call(FunAst, Args, Env0) ->
   {AnnotatedFunAst, Env1} = infer(FunAst, Env0),
   FunType = fetch(AnnotatedFunAst),
@@ -744,7 +755,7 @@ new_env() ->
     {"!=", NEq},
     {"|>", Pipe}
   ],
-  Insert = fun({Name, Type}, Env) -> env_extend(Name, Type, Env) end,
+  Insert = fun({Name, Type}, Env) -> env_extend(Name, Type, module, Env) end,
   lists:foldl(Insert, LastE, Core).
 
 -spec fail(tuple()) -> no_return().
@@ -775,9 +786,11 @@ increment_env_level_test() ->
   ?assertEqual(43, Env3#env.level).
 -endif.
 
--spec env_extend(var_name(), type(), env()) -> env().
-env_extend(Name, GeneralizedType, Env = #env{vars = Vars}) ->
-  NewVars = maps:put(Name, GeneralizedType, Vars),
+
+-spec env_extend(var_name(), type(), scope(), env()) -> env().
+env_extend(Name, Type, Scope, Env = #env{vars = Vars}) ->
+  VarData = #var_data{type = Type, scope = Scope},
+  NewVars = maps:put(Name, VarData, Vars),
   Env#env{vars = NewVars}.
 
 % TODO: Raise if we attempt to overwrite an existing type.

--- a/compiler/test/gleam_codegen_test.erl
+++ b/compiler/test/gleam_codegen_test.erl
@@ -158,12 +158,15 @@ list_test() ->
 
 call_test() ->
   Source =
-    "pub fn double(x) { ok(add(x, x)) }\n"
-    "fn add(x, y) { x + y }\n"
     "fn ok(x) { {'ok', x} }\n"
+    "fn add(x, y) { x + y }\n"
+    "pub fn double(x) { ok(add(x, x)) }\n"
+    "pub fn call_this(x) { x() }\n"
   ,
-  with_module(gleam_codegen_call, Source, fun() ->
-    ?assertEqual({ok, 10}, gleam_codegen_call:double(5))
+  Mod = gleam_codegen_call,
+  with_module(Mod, Source, fun() ->
+    ?assertEqual({ok, 10}, Mod:double(5)),
+    ?assertEqual(ok, Mod:call_this(fun() -> ok end))
   end).
 
 seq_test() ->

--- a/compiler/test/gleam_codegen_test.erl
+++ b/compiler/test/gleam_codegen_test.erl
@@ -169,12 +169,13 @@ call_test() ->
 
 call_local_test() ->
   Source =
-    % "pub fn call_this(x) { x() }\n"
+    "pub fn call_this(x) { x() }\n"
     "pub fn call_internal() { x = fn() { 1 } x() }\n"
   ,
   Mod = gleam_codegen_call_local,
   with_module(Mod, Source, fun() ->
-    ?assertEqual(1, Mod:call_internal())
+    ?assertEqual(1, Mod:call_internal()),
+    ?assertEqual(2, Mod:call_this(fun() -> 2 end))
   end).
 
 
@@ -389,8 +390,8 @@ record_access_test() ->
 
 zero_arity_call_test() ->
   Source =
-    "pub fn one() { hidden() }\n"
     "fn hidden() { 100 }\n"
+    "pub fn one() { hidden() }\n"
   ,
   Mod = gleam_codegen_zero_arity_call,
   with_module(Mod, Source, fun() ->

--- a/compiler/test/gleam_codegen_test.erl
+++ b/compiler/test/gleam_codegen_test.erl
@@ -161,13 +161,22 @@ call_test() ->
     "fn ok(x) { {'ok', x} }\n"
     "fn add(x, y) { x + y }\n"
     "pub fn double(x) { ok(add(x, x)) }\n"
-    "pub fn call_this(x) { x() }\n"
   ,
   Mod = gleam_codegen_call,
   with_module(Mod, Source, fun() ->
-    ?assertEqual({ok, 10}, Mod:double(5)),
-    ?assertEqual(ok, Mod:call_this(fun() -> ok end))
+    ?assertEqual({ok, 10}, Mod:double(5))
   end).
+
+call_local_test() ->
+  Source =
+    % "pub fn call_this(x) { x() }\n"
+    "pub fn call_internal() { x = fn() { 1 } x() }\n"
+  ,
+  Mod = gleam_codegen_call_local,
+  with_module(Mod, Source, fun() ->
+    ?assertEqual(1, Mod:call_internal())
+  end).
+
 
 seq_test() ->
   Source =


### PR DESCRIPTION
No longer needed as we can tell the scope of the variable with the type inference system.