### PR TITLE
Fix typo in tuple.md

### DIFF
--- a/book/src/tour/tuple.md
+++ b/book/src/tour/tuple.md
@@ -15,5 +15,5 @@ let values = {1, 2.0}
 let {x, y} = values
 
 x  // => 1
-y  // => 1.0
+y  // => 2.0
 ```


### PR DESCRIPTION
`2.0` will be assigned to`y` instead of `1.0`