### PR TITLE
Remove gleam dependency for make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ COMPILER=$(realpath gleam/target/release/gleam)
 build: book gleam gleam_stdlib/gen ## Build all targets
 
 .PHONY: install
-install: gleam ## Build the Gleam compiler and place it on PATH
+install: ## Build the Gleam compiler and place it on PATH
 	cd gleam && cargo install --path . --force
 
 .PHONY: help


### PR DESCRIPTION
Currently, `make install` results in the following:
```sh
$ make install
make: *** No rule to make target 'gleam/target/release/gleam', needed by 'gleam'.  Stop.
```

`cd gleam && cargo install --path . --force` seemed to be accomplishing the task described by the comment, so removing the dependency solved the issue. Not sure if this is what you want, but wanted to draw attention to it regardless. :)