### PR TITLE
Implement str:parse_int and str:parse_float

### DIFF
--- a/gleam_stdlib/README.md
+++ b/gleam_stdlib/README.md
@@ -7,3 +7,8 @@ Build
 -----
 
     $ rebar3 compile
+
+Run Tests
+-----
+
+    $ rebar3 eunit

--- a/gleam_stdlib/gen/str.erl
+++ b/gleam_stdlib/gen/str.erl
@@ -2,7 +2,7 @@
 -compile(no_auto_import).
 -include_lib("eunit/include/eunit.hrl").
 
--export([length/1, lowercase/1, uppercase/1, reverse/1, split/2, replace/3, from_int/1, parse_int/1, base_from_int/2, from_float/1]).
+-export([length/1, lowercase/1, uppercase/1, reverse/1, split/2, replace/3, from_int/1, parse_int/1, parse_float/1, base_from_int/2, from_float/1]).
 
 length(A) ->
     string:length(A).
@@ -79,6 +79,19 @@ parse_int_test() ->
     expect:equal(parse_int(<<"">>), {error, parse_error}),
     expect:equal(parse_int(<<"what">>), {error, parse_error}),
     expect:equal(parse_int(<<"1.23">>), {error, parse_error}).
+-endif.
+
+parse_float(A) ->
+    gleam__stdlib:parse_float(A).
+
+-ifdef(TEST).
+parse_float_test() ->
+    expect:equal(parse_float(<<"1.23">>), {ok, 1.23}),
+    expect:equal(parse_float(<<"5.0">>), {ok, 5.0}),
+    expect:equal(parse_float(<<"0.123456789">>), {ok, 0.123456789}),
+    expect:equal(parse_float(<<"">>), {error, parse_error}),
+    expect:equal(parse_float(<<"what">>), {error, parse_error}),
+    expect:equal(parse_float(<<"1">>), {error, parse_error}).
 -endif.
 
 base_from_int(A, B) ->

--- a/gleam_stdlib/gen/str.erl
+++ b/gleam_stdlib/gen/str.erl
@@ -2,7 +2,7 @@
 -compile(no_auto_import).
 -include_lib("eunit/include/eunit.hrl").
 
--export([length/1, lowercase/1, uppercase/1, reverse/1, split/2, replace/3, from_int/1, base_from_int/2, from_float/1]).
+-export([length/1, lowercase/1, uppercase/1, reverse/1, split/2, replace/3, from_int/1, parse_int/1, base_from_int/2, from_float/1]).
 
 length(A) ->
     string:length(A).
@@ -66,6 +66,16 @@ from_int_test() ->
     expect:equal(from_int(123), <<"123">>),
     expect:equal(from_int(-123), <<"-123">>),
     expect:equal(from_int(123), <<"123">>).
+-endif.
+
+parse_int(A) ->
+    gleam__stdlib:parse_int(A).
+
+-ifdef(TEST).
+parse_int_test() ->
+    expect:equal(parse_int(<<"123">>), {ok, 123}),
+    expect:equal(parse_int(<<"-123">>), {ok, -123}),
+    expect:equal(parse_int(<<"0123">>), {ok, 123}).
 -endif.
 
 base_from_int(A, B) ->

--- a/gleam_stdlib/gen/str.erl
+++ b/gleam_stdlib/gen/str.erl
@@ -76,7 +76,9 @@ parse_int_test() ->
     expect:equal(parse_int(<<"123">>), {ok, 123}),
     expect:equal(parse_int(<<"-123">>), {ok, -123}),
     expect:equal(parse_int(<<"0123">>), {ok, 123}),
-    expect:equal(parse_int(<<"what">>), {error, parse_error}).
+    expect:equal(parse_int(<<"">>), {error, parse_error}),
+    expect:equal(parse_int(<<"what">>), {error, parse_error}),
+    expect:equal(parse_int(<<"1.23">>), {error, parse_error}).
 -endif.
 
 base_from_int(A, B) ->

--- a/gleam_stdlib/gen/str.erl
+++ b/gleam_stdlib/gen/str.erl
@@ -75,7 +75,8 @@ parse_int(A) ->
 parse_int_test() ->
     expect:equal(parse_int(<<"123">>), {ok, 123}),
     expect:equal(parse_int(<<"-123">>), {ok, -123}),
-    expect:equal(parse_int(<<"0123">>), {ok, 123}).
+    expect:equal(parse_int(<<"0123">>), {ok, 123}),
+    expect:equal(parse_int(<<"what">>), {error, parse_error}).
 -endif.
 
 base_from_int(A, B) ->

--- a/gleam_stdlib/src/gleam__stdlib.erl
+++ b/gleam_stdlib/src/gleam__stdlib.erl
@@ -6,7 +6,7 @@
          atom_create_from_string/1, atom_to_string/1, map_fetch/2,
          iodata_append/2, iodata_prepend/2, identity/1, decode_int/1,
          decode_string/1, decode_bool/1, decode_float/1, decode_thunk/1,
-         decode_tuple/1, decode_list/1, decode_field/2]).
+         decode_tuple/1, decode_list/1, decode_field/2, parse_int/1]).
 
 expect_equal(Actual, Expected) -> ?assertEqual(Expected, Actual).
 expect_not_equal(Actual, Expected) -> ?assertNotEqual(Expected, Actual).
@@ -68,4 +68,13 @@ decode_field(Data, Key) ->
 
     _ ->
       decode_error_msg(io_lib:format("a map with key `~p`", [Key]), Data)
+  end.
+
+parse_int(String) ->
+  case string:to_integer(String) of
+    {Integer, []} ->
+      {ok, Integer};
+
+    _ ->
+      {error, parse_error}
   end.

--- a/gleam_stdlib/src/gleam__stdlib.erl
+++ b/gleam_stdlib/src/gleam__stdlib.erl
@@ -6,7 +6,7 @@
          atom_create_from_string/1, atom_to_string/1, map_fetch/2,
          iodata_append/2, iodata_prepend/2, identity/1, decode_int/1,
          decode_string/1, decode_bool/1, decode_float/1, decode_thunk/1,
-         decode_tuple/1, decode_list/1, decode_field/2, parse_int/1]).
+         decode_tuple/1, decode_list/1, decode_field/2, parse_int/1, parse_float/1]).
 
 expect_equal(Actual, Expected) -> ?assertEqual(Expected, Actual).
 expect_not_equal(Actual, Expected) -> ?assertNotEqual(Expected, Actual).
@@ -78,3 +78,12 @@ parse_int(String) ->
     _ ->
       {error, parse_error}
   end.
+
+parse_float(String) ->
+    case string:to_float(binary:bin_to_list(String)) of
+        {Float, []} ->
+            {ok, Float};
+
+        _ ->
+            {error, parse_error}
+    end.

--- a/gleam_stdlib/src/gleam__stdlib.erl
+++ b/gleam_stdlib/src/gleam__stdlib.erl
@@ -71,7 +71,7 @@ decode_field(Data, Key) ->
   end.
 
 parse_int(String) ->
-  case string:to_integer(String) of
+  case string:to_integer(binary:bin_to_list(String)) of
     {Integer, []} ->
       {ok, Integer};
 

--- a/gleam_stdlib/src/gleam__stdlib.erl
+++ b/gleam_stdlib/src/gleam__stdlib.erl
@@ -80,10 +80,10 @@ parse_int(String) ->
   end.
 
 parse_float(String) ->
-    case string:to_float(binary:bin_to_list(String)) of
-        {Float, []} ->
-            {ok, Float};
+  case string:to_float(binary:bin_to_list(String)) of
+    {Float, []} ->
+      {ok, Float};
 
-        _ ->
-            {error, parse_error}
-    end.
+    _ ->
+      {error, parse_error}
+  end.

--- a/gleam_stdlib/src/str.gleam
+++ b/gleam_stdlib/src/str.gleam
@@ -121,6 +121,34 @@ test parse_int {
   |> expect:equal(_, Error(ParseError))
 }
 
+pub external fn parse_float(String) -> Result(Float, ParseError) = "gleam__stdlib" "parse_float";
+
+test parse_float {
+  "1.23"
+  |> parse_float
+  |> expect:equal(_, Ok(1.23))
+
+  "5.0"
+  |> parse_float
+  |> expect:equal(_, Ok(5.0))
+
+  "0.123456789"
+  |> parse_float
+  |> expect:equal(_, Ok(0.123456789))
+
+  ""
+  |> parse_float
+  |> expect:equal(_, Error(ParseError))
+
+  "what"
+  |> parse_float
+  |> expect:equal(_, Error(ParseError))
+
+  "1"
+  |> parse_float
+  |> expect:equal(_, Error(ParseError))
+}
+
 pub external fn base_from_int(Int, Int) -> String = "erlang" "integer_to_binary"
 
 test base_from_int {

--- a/gleam_stdlib/src/str.gleam
+++ b/gleam_stdlib/src/str.gleam
@@ -107,6 +107,10 @@ test parse_int {
   "0123"
   |> parse_int
   |> expect:equal(_, Ok(123))
+
+  "what"
+  |> parse_int
+  |> expect:equal(_, Error(ParseError))
 }
 
 pub external fn base_from_int(Int, Int) -> String = "erlang" "integer_to_binary"

--- a/gleam_stdlib/src/str.gleam
+++ b/gleam_stdlib/src/str.gleam
@@ -7,6 +7,9 @@ import list
 
 pub external fn length(String) -> Int = "string" "length"
 
+pub enum ParseError =
+  | ParseError
+
 test length {
   length("ß↑e̊")
   |> expect:equal(_, 3)
@@ -88,6 +91,22 @@ test from_int {
   0123
   |> from_int
   |> expect:equal(_, "123")
+}
+
+pub external fn parse_int(String) -> Result(Int, ParseError) = "gleam__stdlib" "parse_int";
+
+test parse_int {
+  "123"
+  |> parse_int
+  |> expect:equal(_, Ok(123))
+
+  "-123"
+  |> parse_int
+  |> expect:equal(_, Ok(-123))
+
+  "0123"
+  |> parse_int
+  |> expect:equal(_, Ok(123))
 }
 
 pub external fn base_from_int(Int, Int) -> String = "erlang" "integer_to_binary"

--- a/gleam_stdlib/src/str.gleam
+++ b/gleam_stdlib/src/str.gleam
@@ -108,7 +108,15 @@ test parse_int {
   |> parse_int
   |> expect:equal(_, Ok(123))
 
+  ""
+  |> parse_int
+  |> expect:equal(_, Error(ParseError))
+
   "what"
+  |> parse_int
+  |> expect:equal(_, Error(ParseError))
+
+  "1.23"
   |> parse_int
   |> expect:equal(_, Error(ParseError))
 }


### PR DESCRIPTION
Issue: https://github.com/lpil/gleam/issues/116

I have no idea if this approach is desired, but thought I'd take a stab at it using pre-existing code as a rough guideline. Is this along the right track, or are we going for something different? (maybe pure-gleam implementation)?

Also, have no idea how to verify that it works :p. Was wondering if you could point me in the right direction there.

If green-lit, I'll go ahead w/ `str:parse_float` in the desired method.