### PR TITLE
Adds upgrade target to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,14 @@ build: book gleam gleam_stdlib/gen ## Build all targets
 install: ## Build the Gleam compiler and place it on PATH
 	cd gleam && cargo install --path . --force
 
+.PHONY: upgrade
+upgrade: ## Fetch by version tag using arg version=v0.x.x and install
+	git fetch &&\
+	git fetch --tags &&\
+	git checkout v$(version) &&\
+	make install &&\
+	rebar3 as global plugins upgrade rebar_gleam
+
 .PHONY: help
 help:
 	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
When trying out Gleam I ran into several issues trying to upgrade to a stable commit because it was just using master which happened to break something and my rebar_gleam didn't update itself.

I made this makefile target for my own use to help out with this upgrade process and I wanted to show it to you in case you thought it's something that would be useful for an interim solution.

Also i'm not sure if it would be overkill to make a `fetch-version` target and a `upgrade-rebar-gleam` target and then calling `upgrade: fetch-version install upgrade-rebar` so that you don't have to call `make install`.

Please feel free to suggest edits or close the PR all together as I realize it may not be a fit for general use.

Thanks and keep up the good work!