### PR TITLE
Fix typo in spelling of dependencies

### DIFF
--- a/gleam/src/ast.rs
+++ b/gleam/src/ast.rs
@@ -16,7 +16,7 @@ impl<S, T> Module<S, T> {
         self.name.join("/")
     }
 
-    pub fn dependancies(&self) -> Vec<(String, Meta)> {
+    pub fn dependencies(&self) -> Vec<(String, Meta)> {
         self.statements
             .iter()
             .flat_map(|s| match s {
@@ -38,7 +38,7 @@ fn module_dependencies_test() {
         crate::grammar::ModuleParser::new()
             .parse("import foo import bar import foo_bar")
             .expect("syntax error")
-            .dependancies()
+            .dependencies()
     );
 }
 

--- a/gleam/src/project.rs
+++ b/gleam/src/project.rs
@@ -612,8 +612,7 @@ pub fn compile(srcs: Vec<Input>) -> Result<Vec<Compiled>, Error> {
         let module_name = module.module.name_string();
         let src = module.src.clone();
         let path = module.path.clone();
-        let deps = module.module.dependancies();
-        // (module_name, src, path, deps)
+        let deps = module.module.dependencies();
         let module_index = indexes
             .get(&module_name)
             .expect("Unable to find module index");


### PR DESCRIPTION
`dependancies` → `dependencies`