### PR TITLE
Error-formatted message for Error::DuplicateModule

### DIFF
--- a/gleam/src/project.rs
+++ b/gleam/src/project.rs
@@ -543,6 +543,26 @@ fn write(mut buffer: &mut Buffer, d: ErrorDiagnostic) {
     codespan_reporting::emit(&mut buffer, &code_map, &diagnostic).unwrap();
 }
 
+/// Describes an error encountered while compiling the project (eg. a name collision
+/// between files).
+///
+struct ProjectErrorDiagnostic {
+    title: String,
+    label: String,
+}
+
+fn write_project(mut buffer: &mut Buffer, d: ProjectErrorDiagnostic) {
+    use codespan::{CodeMap, Span};
+    use codespan_reporting::{Diagnostic, Label};
+
+    let code_map: CodeMap<String> = CodeMap::new();
+    let diagnostic = Diagnostic::new_error(d.title).with_label(
+        Label::new_primary(Span::new(0.into(), 0.into()))
+            .with_message(d.label),
+    );
+    codespan_reporting::emit(&mut buffer, &code_map, &diagnostic).unwrap();
+}
+
 pub fn compile(srcs: Vec<Input>) -> Result<Vec<Compiled>, Error> {
     struct Module {
         src: String,

--- a/gleam/src/project.rs
+++ b/gleam/src/project.rs
@@ -108,21 +108,19 @@ cannot import them. Perhaps move the `{}` module to the src directory.
                 first,
                 second,
             } => {
-                // TODO: Colours
-                write!(
-                    buffer,
-                    "error: Duplicate module
+                let diagnostic = ProjectErrorDiagnostic {
+                    title: "Duplicate module".to_string(),
+                    label: format!(
+                        "The module `{}` is defined multiple times.
 
-The module {} is defined multiple times.
-
-First: {}
-Then:  {}
-",
-                    module,
-                    first.to_str().expect("pretty error print PathBuf to_str"),
-                    second.to_str().expect("pretty error print PathBuf to_str"),
-                )
-                .unwrap();
+First:  {}
+Second: {}",
+                        module,
+                        first.to_str().expect("pretty error print PathBuf to_str"),
+                        second.to_str().expect("pretty error print PathBuf to_str"),
+                    ),
+                };
+                write_project(buffer, diagnostic);
             }
 
             Error::Type { path, src, error } => match error {


### PR DESCRIPTION
Introduces a new `ProjectErrorDiagnostic` struct for describing project-level errors as a sort of companion to the source-level `ErrorDiagnostic`. Then uses it to report the duplicate module error message with a pretty formatting like other errors.

The new struct might be premature abstraction; the scaffolding for `codespan_reporting` can easily be called via a function directly without the struct in the middle, or it can be inlined into that branch of the `match`.

Fixes #218