### PR TITLE
Implement string:compare

### DIFF
--- a/gleam_stdlib/gen/src/gleam@string.erl
+++ b/gleam_stdlib/gen/src/gleam@string.erl
@@ -1,7 +1,7 @@
 -module(gleam@string).
 -compile(no_auto_import).
 
--export([length/1, lowercase/1, uppercase/1, reverse/1, split/2, replace/3, append/2]).
+-export([length/1, lowercase/1, uppercase/1, compare/2, reverse/1, split/2, replace/3, append/2]).
 
 length(A) ->
     string:length(A).
@@ -11,6 +11,9 @@ lowercase(A) ->
 
 uppercase(A) ->
     string:uppercase(A).
+
+compare(A, B) ->
+    gleam_stdlib:compare_strings(A, B).
 
 reverse(String) ->
     gleam@iodata:to_string(gleam@iodata:reverse(gleam@iodata:new(String))).

--- a/gleam_stdlib/gen/test/gleam@string_test.erl
+++ b/gleam_stdlib/gen/test/gleam@string_test.erl
@@ -1,7 +1,7 @@
 -module(gleam@string_test).
 -compile(no_auto_import).
 
--export([length_test/0, lowercase_test/0, uppercase_test/0, reverse_test/0, split_test/0, replace_test/0, append_test/0]).
+-export([length_test/0, lowercase_test/0, uppercase_test/0, reverse_test/0, split_test/0, replace_test/0, append_test/0, compare_test/0]).
 
 length_test() ->
     gleam@expect:equal(gleam@string:length(<<"ß↑e̊">>), 3),
@@ -38,3 +38,10 @@ append_test() ->
         gleam@string:append(<<"Test">>, <<" Me">>),
         <<"Test Me">>
     ).
+
+compare_test() ->
+    gleam@expect:equal(gleam@string:compare(<<"">>, <<"">>), eq),
+    gleam@expect:equal(gleam@string:compare(<<"a">>, <<"">>), gt),
+    gleam@expect:equal(gleam@string:compare(<<"a">>, <<"A">>), gt),
+    gleam@expect:equal(gleam@string:compare(<<"A">>, <<"B">>), lt),
+    gleam@expect:equal(gleam@string:compare(<<"t">>, <<"ABC">>), gt).

--- a/gleam_stdlib/src/gleam/string.gleam
+++ b/gleam_stdlib/src/gleam/string.gleam
@@ -1,11 +1,15 @@
 import gleam/iodata
 import gleam/list
+import gleam/order
 
 pub external fn length(String) -> Int = "string" "length"
 
 pub external fn lowercase(String) -> String = "string" "lowercase"
 
 pub external fn uppercase(String) -> String = "string" "uppercase"
+
+pub external fn compare(String, String) -> order.Order =
+  "gleam_stdlib" "compare_strings"
 
 pub fn reverse(string) {
   string

--- a/gleam_stdlib/src/gleam_stdlib.erl
+++ b/gleam_stdlib/src/gleam_stdlib.erl
@@ -6,7 +6,7 @@
          atom_create_from_string/1, atom_to_string/1, map_fetch/2,
          iodata_append/2, iodata_prepend/2, identity/1, decode_int/1,
          decode_string/1, decode_bool/1, decode_float/1, decode_thunk/1, decode_atom/1,
-         decode_pair/1, decode_list/1, decode_field/2, parse_int/1, parse_float/1]).
+         decode_pair/1, decode_list/1, decode_field/2, parse_int/1, parse_float/1, compare_strings/2]).
 
 expect_equal(Actual, Expected) -> ?assertEqual(Expected, Actual).
 expect_not_equal(Actual, Expected) -> ?assertNotEqual(Expected, Actual).
@@ -89,4 +89,14 @@ parse_float(String) ->
 
     _ ->
       {error, nil}
+  end.
+
+compare_strings(Lhs, Rhs) ->
+  if
+    Lhs == Rhs ->
+      eq;
+    Lhs < Rhs ->
+      lt;
+    true ->
+     gt
   end.

--- a/gleam_stdlib/test/gleam/string_test.gleam
+++ b/gleam_stdlib/test/gleam/string_test.gleam
@@ -1,5 +1,6 @@
 import gleam/string
 import gleam/expect
+import gleam/order
 
 pub fn length_test() {
   string.length("ß↑e̊")
@@ -47,4 +48,21 @@ pub fn append_test() {
   "Test"
   |> string.append(_, " Me")
   |> expect.equal(_, "Test Me")
+}
+
+pub fn compare_test() {
+  string.compare("", "")
+  |> expect.equal(_, order.Eq)
+
+  string.compare("a", "")
+  |> expect.equal(_, order.Gt)
+
+  string.compare("a", "A")
+  |> expect.equal(_, order.Gt)
+
+  string.compare("A", "B")
+  |> expect.equal(_, order.Lt)
+
+  string.compare("t", "ABC")
+  |> expect.equal(_, order.Gt)
 }


### PR DESCRIPTION
An attempt at implementing: https://github.com/lpil/gleam/issues/216; basically just leans on erlang's rules for string comparison.

I wasn't sure if there was a way to cleanly return something from `erlang` that'd resolve as an enum-variant in `gleam`, and also couldn't find a way to refer to atoms, so I went w/ integers that map to the `order` enum variants.