### PR TITLE
Create simple GitHub Actions workflow.

### DIFF
--- a/.github/workflows/build_compiler.yaml
+++ b/.github/workflows/build_compiler.yaml
@@ -1,0 +1,14 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build_compiler:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - run: cd gleam && cargo test
+      - run: cd gleam && cargo build --release
+      - run: gleam/target/release/gleam --version
+      - run: gleam/target/release/gleam build gleam_stdlib


### PR DESCRIPTION
This Pull Request is related to issue #232.

I created a simple GitHub Actions workflow which replicates current Circle CI build process. It doesn't use cache, since that is not available in GitHub Actions yet.

What should be the output of this workflow? Is the successfull run of all the commands good enough enough, or should this workflow produce some artifacts or a GitHub Release?

GitHub Actions supports MacOS runners too, so it is possible to even do a release after a new tag is created in the repository along with the linux and macos binaries. I assume you're doing this manually now. Am I right?